### PR TITLE
[chore] adding missing openzepplin contract dependency and vesrion

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "^3.2.0",
     "@zoralabs/core": "^1.0.3",
     "dotenv": "^8.2.0",
     "fs-extra": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,6 +680,11 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts@^3.2.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1.tgz#03c891fec7f93be0ae44ed74e57a122a38732ce7"
+  integrity sha512-cUriqMauq1ylzP2TxePNdPqkwI7Le3Annh4K9rrpvKfSBB/bdW+Iu1ihBaTIABTAAJ85LmKL5SSPPL9ry8d1gQ==
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
Adding explicit dependency for openzepplin contracts matching the version of openzepplin used in the zora core contracts.