### PR TITLE
Feature/royalty payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ coverage.json
 .env.prod
 .env.*
 
+.vscode
+
 dist

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -266,7 +266,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
                 auctions[auctionId].bidder,
                 tokenOwnerProfit,
                 commissionAddress,
-                commissionAmount            
+                commissionAmount,            
                 currency
             );
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -252,9 +252,9 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         if (auctions[auctionId].commissionAddress != address(0) && auctions[auctionId].commissionPercentage > 0){
             uint256 commissionAmount = _generateCommission(auctionId);
-            uint256 tokenOwnerRemainingAmount = tokenOwnerProfit.sub(commissionAmount);
+            uint256 amountRemaining = tokenOwnerProfit.sub(commissionAmount);
 
-            _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(auctions[auctionId].tokenOwner, amountRemaining, auctions[auctionId].auctionCurrency);
 
             _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -120,7 +120,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionReservePriceUpdated(auctionId, auctions[auctionId].tokenId, auctions[auctionId].tokenContract, reservePrice);
     }
 
-    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external auctionExists(auctionId) {
+    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external override auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 
@@ -129,7 +129,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionCommissionAddressUpdated(auctionId, commissionAddress);
     }
 
-    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external auctionExists(auctionId) {
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external override auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -256,7 +256,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
             _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
 
-            _handleOutGoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
+            _handleOutgoingBid(auctions[auctionId].commissionAddress, commissionAmount, auctions[auctionId].auctionCurrency);
 
             emit AuctionWithCommissionEnded(
                 auctionId,

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -252,7 +252,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         if (auctions[auctionId].commissionAddress != address(0) && auctions[auctionId].commissionPercentage > 0){
             uint256 commissionAmount = _generateCommission(auctionId);
-            tokenOwnerProfit = tokenOwnerProfit.sub(commissionAmount);
+            uint256 tokenOwnerRemainingAmount = tokenOwnerProfit.sub(commissionAmount);
 
             _handleOutgoingBid(auctions[auctionId].tokenOwner, tokenOwnerProfit, auctions[auctionId].auctionCurrency);
 
@@ -265,7 +265,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
                 auctions[auctionId].tokenOwner,            
                 auctions[auctionId].bidder,
                 tokenOwnerProfit,
-                commissionAddress,
+                auctions[auctionId].commissionAddress,
                 commissionAmount,            
                 currency
             );

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -337,7 +337,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateCommission(uint256 auctionId) internal return (uint256){
+    function _generateCommission(uint256 auctionId) internal {
         return auctions[auctionId].amount.div(100).mul(auctions[auctionId].commissionPercentage);
     }
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -129,7 +129,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         emit AuctionCommissionAddressUpdated(auctionId, commissionAddress);
     }
 
-    function updateCommissionPercentage(uint256 auctionId, uint8 commissionPercentage) external auctionExists(auctionId) {
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external auctionExists(auctionId) {
         // TODO - access controls
         require(auctions[auctionId].firstBidTime == 0, "Auction has already started");
 

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -97,7 +97,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             reservePrice: reservePrice,            
             tokenOwner: tokenOwner,
             bidder: address(0),            
-            auctionCurrency: auctionCurrency
+            auctionCurrency: auctionCurrency,
             commissionAddress: commissionAddress,
             commissionPercentage: comissionPercentage
         });

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -106,7 +106,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
 
         _auctionIdTracker.increment();
 
-        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency);
+        emit AuctionCreated(auctionId, tokenId, tokenContract, duration, reservePrice, tokenOwner, auctionCurrency, commissionAddress, commissionPercentage);
  
         return auctionId;
     }

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -99,7 +99,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
             bidder: address(0),            
             auctionCurrency: auctionCurrency,
             commissionAddress: commissionAddress,
-            commissionPercentage: comissionPercentage
+            commissionPercentage: commissionPercentage
         });
 
         IERC721(tokenContract).transferFrom(tokenOwner, address(this), tokenId);

--- a/contracts/AuctionHouse.sol
+++ b/contracts/AuctionHouse.sol
@@ -337,7 +337,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuard {
         }
     }
 
-    function _generateCommission(uint256 auctionId) internal {
+    function _generateCommission(uint256 auctionId) internal returns (uint256) {
         return auctions[auctionId].amount.div(100).mul(auctions[auctionId].commissionPercentage);
     }
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -98,7 +98,7 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
-    event AuctionEndedWithCommission(
+    event AuctionWithCommissionEnded(
         uint256 indexed auctionId,
         uint256 indexed tokenId,
         address indexed tokenContract,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -130,9 +130,9 @@ interface IAuctionHouse {
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 
-    function updateCommissionAddress(address commissionAddress) external;
+    function updateCommissionAddress(uint256 auctionId, address commissionAddress) external;
 
-    function updateCommissionPercentage(address commissionAddress) external;
+    function updateCommissionPercentage(uint256 auctionId, address commissionAddress) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -98,6 +98,18 @@ interface IAuctionHouse {
         address auctionCurrency
     );
 
+    event AuctionEndedWithCommission(
+        uint256 indexed auctionId,
+        uint256 indexed tokenId,
+        address indexed tokenContract,
+        address tokenOwner,        
+        address winner,
+        uint256 amount,
+        address commissionAddress,
+        uint256 commissionAmount,        
+        address auctionCurrency
+    );
+
     event AuctionCanceled(
         uint256 indexed auctionId,
         uint256 indexed tokenId,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -62,12 +62,12 @@ interface IAuctionHouse {
     );
 
     event AuctionCommissionAddressUpdated(
-        uint256 indexed auctionId
+        uint256 indexed auctionId,
         address indexed commissionAddress
     )
 
     event AuctionCommissionAddressUpdated(
-        uint256 indexed auctionId
+        uint256 indexed auctionId,
         address indexed commissionAddress
     )
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -27,6 +27,13 @@ interface IAuctionHouse {
         // The address of the ERC-20 currency to run the auction with.
         // If set to 0x0, the auction will be run in ETH
         address auctionCurrency;
+        // The address of recipient of the sale commission
+        address commissionAddress;
+        //The address of the recipient of the sale commission
+        //If set to 0x0, no commission will generated
+        uint256 commissionPercentage;
+        // The percentage of the sale the commission address receives
+        //If percentage is set to 0, no commission will be generated
     }
 
     event AuctionCreated(
@@ -36,7 +43,9 @@ interface IAuctionHouse {
         uint256 duration,
         uint256 reservePrice,
         address tokenOwner,        
-        address auctionCurrency
+        address auctionCurrency,
+        address commissionAddress,
+        uint8 commissionPercentage
     );
 
     event AuctionApprovalUpdated(
@@ -51,6 +60,16 @@ interface IAuctionHouse {
         address indexed tokenContract,
         uint256 reservePrice
     );
+
+    event AuctionCommissionAddressUpdated(
+        uint256 indexed auctionId
+        address indexed commissionAddress
+    )
+
+    event AuctionCommissionAddressUpdated(
+        uint256 indexed auctionId
+        address indexed commissionAddress
+    )
 
     event AuctionBid(
         uint256 indexed auctionId,
@@ -91,11 +110,17 @@ interface IAuctionHouse {
         address tokenContract,
         uint256 duration,
         uint256 reservePrice,        
-        address auctionCurrency
+        address auctionCurrency,
+        address commissionAddress,
+        uint8 comissionPercentage
     ) external returns (uint256);
 
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
+
+    function updateCommissionAddress(address commissionAddress) external;
+
+    function updateCommissionPercentage(address commissionAddress) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -64,12 +64,12 @@ interface IAuctionHouse {
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
         address indexed commissionAddress
-    )
+    );
 
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
         address indexed commissionAddress
-    )
+    );
 
     event AuctionBid(
         uint256 indexed auctionId,

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -132,7 +132,7 @@ interface IAuctionHouse {
 
     function updateCommissionAddress(uint256 auctionId, address commissionAddress) external;
 
-    function updateCommissionPercentage(uint256 auctionId, address commissionAddress) external;
+    function updateCommissionPercentage(uint256 auctionId, uint256 commissionPercentage) external;
 
     function createBid(uint256 auctionId, uint256 amount) external payable;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -11,9 +11,7 @@ interface IAuctionHouse {
         // ID for the ERC721 token
         uint256 tokenId;
         // Address for the ERC721 contract
-        address tokenContract;
-        // Whether or not the auction curator has approved the auction to start
-        bool approved;
+        address tokenContract;        
         // The current highest bid amount
         uint256 amount;
         // The length of time to run the auction for, after the first bid was made
@@ -22,15 +20,10 @@ interface IAuctionHouse {
         uint256 firstBidTime;
         // The minimum price of the first bid
         uint256 reservePrice;
-        // The sale percentage to send to the curator
-        uint8 curatorFeePercentage;
         // The address that should receive the funds once the NFT is sold.
         address tokenOwner;
         // The address of the current highest bid
-        address payable bidder;
-        // The address of the auction's curator.
-        // The curator can reject or approve an auction
-        address payable curator;
+        address payable bidder;        
         // The address of the ERC-20 currency to run the auction with.
         // If set to 0x0, the auction will be run in ETH
         address auctionCurrency;
@@ -42,17 +35,14 @@ interface IAuctionHouse {
         address indexed tokenContract,
         uint256 duration,
         uint256 reservePrice,
-        address tokenOwner,
-        address curator,
-        uint8 curatorFeePercentage,
+        address tokenOwner,        
         address auctionCurrency
     );
 
     event AuctionApprovalUpdated(
         uint256 indexed auctionId,
         uint256 indexed tokenId,
-        address indexed tokenContract,
-        bool approved
+        address indexed tokenContract        
     );
 
     event AuctionReservePriceUpdated(
@@ -83,11 +73,9 @@ interface IAuctionHouse {
         uint256 indexed auctionId,
         uint256 indexed tokenId,
         address indexed tokenContract,
-        address tokenOwner,
-        address curator,
+        address tokenOwner,        
         address winner,
-        uint256 amount,
-        uint256 curatorFee,
+        uint256 amount,        
         address auctionCurrency
     );
 
@@ -102,13 +90,10 @@ interface IAuctionHouse {
         uint256 tokenId,
         address tokenContract,
         uint256 duration,
-        uint256 reservePrice,
-        address payable curator,
-        uint8 curatorFeePercentages,
+        uint256 reservePrice,        
         address auctionCurrency
     ) external returns (uint256);
 
-    function setAuctionApproval(uint256 auctionId, bool approved) external;
 
     function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice) external;
 

--- a/contracts/interfaces/IAuctionHouse.sol
+++ b/contracts/interfaces/IAuctionHouse.sol
@@ -63,12 +63,12 @@ interface IAuctionHouse {
 
     event AuctionCommissionAddressUpdated(
         uint256 indexed auctionId,
-        address indexed commissionAddress
+        address indexed newCommissionAddress
     );
 
-    event AuctionCommissionAddressUpdated(
+    event AuctionCommissionPercentageUpdated(
         uint256 indexed auctionId,
-        address indexed commissionAddress
+        uint256 indexed newCommissionPercentage
     );
 
     event AuctionBid(

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@zoralabs/auction-house",
+  "name": "chainsaw-auction-house",
   "version": "1.1.1",
   "private": false,
-  "homepage": "https://github.com/ourzora/coldies",
+  "homepage": "https://github.com/Chain-saw-NFT/auction-house",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ourzora/coldies.git"
+    "url": "https://github.com/Chain-saw-NFT/auction-house.git"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,8 +43,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^3.2.0",
-    "@zoralabs/core": "^1.0.3",
+    "@openzeppelin/contracts": "^3.2.0",    
     "dotenv": "^8.2.0",
     "fs-extra": "^9.1.0",
     "minimist": "^1.2.5",


### PR DESCRIPTION
Optional commission functionality has been added! 

The auction struct now has two additional properties: commissionAddress and commissionPercentage. When endAuction is now called, if commissionAddress and commissionPercentage exist for the given auction object, the contract will calculate the commission amount and send that to the commission address. The amount remaining will be sent to the token owner. If commissionAddress and commission do not exist, the contract will send the total amount to the tokenOwner as it did before.

There are also two setter functions now for both variables in case we need to change either value after the auction has been created that we will need to limit with access controls eventually.